### PR TITLE
[SDPA-1357] Added patch for flexible index naming.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "composer-exit-on-patch-failure": true,
         "patches": {
             "drupal/elasticsearch_connector": {
-                "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch"
+                "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch",
+                "Allow index name flexibility - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "https://www.drupal.org/files/issues/2018-12-10/elasticsearch_connector-index-name-3010955-6-D8.patch"
             }
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0+",
     "require": {
         "drupal/search_api": "^1.8",
-        "drupal/elasticsearch_connector": "^5.0-alpha2",
+        "drupal/elasticsearch_connector": "^5.0-alpha3",
         "dpc-sdp/tide_core": "@dev"
     },
     "require-dev": {


### PR DESCRIPTION
Applies the patch from https://www.drupal.org/project/elasticsearch_connector/issues/3010955 so that the Elasticsearch index name can be configured.