### PR TITLE
[SDPA-2005] search index does not update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "drupal/search_api": "^1.11",
         "drupal/elasticsearch_connector": "^5.0-alpha3",
-        "dpc-sdp/tide_core": "^1.0"
+        "dpc-sdp/tide_core": "^1.0",
+        "drupal/metatag": "~1.7.0"
     },
     "repositories": {
         "drupal": {
@@ -17,7 +18,8 @@
     "extra": {
         "patches": {
             "drupal/elasticsearch_connector": {
-                "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch"
+                "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch",
+                "[SDPA-2005] Content is still displaying even when content is deleted - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "https://raw.githubusercontent.com/dpc-sdp/tide_search/47105d9e538824334384b92c6fdc6a181f4ec23b/patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "patches": {
             "drupal/elasticsearch_connector": {
                 "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch",
-                "[SDPA-2005] Content is still displaying even when content is deleted - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "./patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch"
+                "[SDPA-2005] Content is still displaying even when content is deleted - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     "extra": {
         "patches": {
             "drupal/elasticsearch_connector": {
-                "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch",
-                "[SDPA-2005] Content is still displaying even when content is deleted - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "https://raw.githubusercontent.com/dpc-sdp/tide_search/47105d9e538824334384b92c6fdc6a181f4ec23b/patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch"
+                "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "patches": {
             "drupal/elasticsearch_connector": {
                 "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch",
-                "[SDPA-2005] Content is still displaying even when content is deleted - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch"
+                "[SDPA-2005] Content is still displaying even when content is deleted - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "https://raw.githubusercontent.com/dpc-sdp/tide_search/47105d9e538824334384b92c6fdc6a181f4ec23b/patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "patches": {
             "drupal/elasticsearch_connector": {
                 "Failed to parse node status - https://www.drupal.org/project/elasticsearch_connector/issues/2978005": "https://www.drupal.org/files/issues/2018-06-07/elasticsearch_connector-convert_boolean_fields-2978005-2.patch",
-                "Allow index name flexibility - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "https://www.drupal.org/files/issues/2018-12-10/elasticsearch_connector-index-name-3010955-6-D8.patch"
+                "[SDPA-2005] Content is still displaying even when content is deleted - https://www.drupal.org/project/elasticsearch_connector/issues/3010955": "./patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch"
             }
         }
     }

--- a/patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch
+++ b/patches/elasticsearch_connector/SDPA-2005_rewrite-index-for-bulkDelete-3010955-6-combined.patch
@@ -1,0 +1,128 @@
+diff --git a/src/ElasticSearch/Parameters/Factory/IndexFactory.php b/src/ElasticSearch/Parameters/Factory/IndexFactory.php
+index 11f7b9c..4114a9e 100644
+--- a/src/ElasticSearch/Parameters/Factory/IndexFactory.php
++++ b/src/ElasticSearch/Parameters/Factory/IndexFactory.php
+@@ -6,11 +6,14 @@ use Drupal\search_api\IndexInterface;
+ use Drupal\elasticsearch_connector\Event\PrepareIndexEvent;
+ use Drupal\elasticsearch_connector\Event\PrepareIndexMappingEvent;
+ use Drupal\search_api_autocomplete\Suggester\SuggesterInterface;
++use Drupal\elasticsearch_connector\Entity\Cluster;
++use Drupal\search_api\Entity\Server;
+ 
+ /**
+  * Create Elasticsearch Indices.
+  */
+ class IndexFactory {
++  const HASH_LENGTH = 32;
+ 
+   /**
+    * Build parameters required to index.
+@@ -84,6 +87,18 @@ class IndexFactory {
+    */
+   public static function bulkDelete(IndexInterface $index, array $ids) {
+     $params = IndexFactory::index($index, TRUE);
++
++    // This convoluted path to the host domain is due to
++    // https://www.drupal.org/project/search_api/issues/2976339 not populating
++    // `search_api.server.server_id` config with the correct values.
++    $cluster_id = Server::load($index->getServerId())->getBackend()->getCluster();
++    $host = parse_url(Cluster::load($cluster_id)->url, PHP_URL_HOST);
++    $hash = strstr($host, '.', TRUE);
++
++    if (isset($hash) && strlen($hash) === self::HASH_LENGTH) {
++      $params['index'] = $hash . '--' . $params['index'];
++    }
++
+     foreach ($ids as $id) {
+       $params['body'][] = [
+         'delete' => [
+@@ -224,15 +239,29 @@ class IndexFactory {
+    */
+   public static function getIndexName(IndexInterface $index) {
+ 
+-    $options = \Drupal::database()->getConnectionOptions();
+-    $site_database = $options['database'];
+-
++    // Get index machine name.
+     $index_machine_name = is_string($index) ? $index : $index->id();
+ 
++    // Get prefix and suffix form the cluster if present.
++    $cluster_id = $index->getServerInstance()->getBackend()->getCluster();
++    $cluster_options = Cluster::load($cluster_id)->options;
++
++    // If  prefix is not set ensure we set it to db name by default.
++    if (isset($cluster_options['rewrite']['rewrite_index'])) {
++      $index_prefix = isset($cluster_options['rewrite']['index']['prefix']) ? $cluster_options['rewrite']['index']['prefix'] : '';
++    }
++    else {
++      $options = \Drupal::database()->getConnectionOptions();
++      $index_prefix = 'elasticsearch_index_' . $options['database'] . '_';
++    }
++
++    // Get the index suffix.
++    $index_suffix = isset($cluster_options['rewrite']['index']['suffix']) ? $cluster_options['rewrite']['index']['suffix'] : '';
++
+     return strtolower(preg_replace(
+       '/[^A-Za-z0-9_]+/',
+       '',
+-      'elasticsearch_index_' . $site_database . '_' . $index_machine_name
++      $index_prefix . $index_machine_name . $index_suffix
+     ));
+   }
+ 
+diff --git a/src/Form/ClusterForm.php b/src/Form/ClusterForm.php
+index 0138a68..d1ccbca 100644
+--- a/src/Form/ClusterForm.php
++++ b/src/Form/ClusterForm.php
+@@ -231,6 +231,51 @@ class ClusterForm extends EntityForm {
+       '#default_value' => (!empty($this->entity->options['timeout']) ? $this->entity->options['timeout'] : Cluster::ELASTICSEARCH_CONNECTOR_DEFAULT_TIMEOUT),
+       '#weight' => 5.6,
+     );
++
++    $form['options']['rewrite'] = [
++      '#tree' => TRUE,
++      '#type' => 'details',
++      '#title' => $this->t('Alter the ES index name.'),
++      '#open' => FALSE,
++      '#weight' => 6,
++    ];
++
++    $form['options']['rewrite']['rewrite_index'] = [
++      '#title' => $this->t('Alter the Elasticsearch index name.'),
++      '#type' => 'checkbox',
++      '#default_value' => (!empty($this->entity->options['rewrite']['rewrite_index']) ? 1 : 0),
++      '#description' => t('Alter the name of the Elasticsearch index by optionally adding a prefix and suffix to the Search API index name.')
++    ];
++
++    $form['options']['rewrite']['index']['prefix'] = [
++      '#type' => 'textfield',
++      '#title' => t('Index name prefix'),
++      '#default_value' => (!empty($this->entity->options['rewrite']['index']['prefix']) ? $this->entity->options['rewrite']['index']['prefix'] : ''),
++      '#description' => t(
++        'If a value is provided it will be prepended to the index name.'
++      ),
++      '#states' => [
++        'visible' => [
++          ':input[name="options[rewrite][rewrite_index]"]' => ['checked' => TRUE],
++        ],
++      ],
++      '#weight' => 6.1,
++    ];
++
++    $form['options']['rewrite']['index']['suffix'] = [
++      '#type' => 'textfield',
++      '#title' => t('Index name suffix'),
++      '#default_value' => (!empty($this->entity->options['rewrite']['index']['suffix']) ? $this->entity->options['rewrite']['index']['suffix'] : ''),
++      '#description' => t(
++        'If a value is provided it will be appended to the index name.'
++      ),
++      '#states' => [
++        'visible' => [
++          ':input[name="options[rewrite][rewrite_index]"]' => ['checked' => TRUE],
++        ],
++      ],
++      '#weight' => 6.2,
++    ];
+   }
+ 
+   /**


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [SDPA-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below

3. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

4. ASSIGNEE: Assign at least 2 reviewers.     

5. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**JIRA issue:** https://digital-engagement.atlassian.net/browse/SDPA-2005

Related PRs
dpc-sdp/content-vic-gov-au#522

### Changed

1.  Patched tide_search/elasticsearch_connector to rewrite the index name on delete queries.

This is the only query I've found in the elasticsearch_connector module that submits an operation with a body that includes the index name so it's the only place that the change is necessary.

I have no plans on putting this up as a d.o patch because the use case is very specific to our project.