### PR TITLE
elasticsearch_connector module fixes the issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,6 @@
     "require": {
         "drupal/search_api": "^1.11",
         "drupal/elasticsearch_connector": "^6.0-alpha2",
-        "nodespark/des-connector": "5.x-dev as 6.x-dev",
         "dpc-sdp/tide_core": "^1.5.1"
     },
     "repositories": {

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,5 @@
             "type": "composer",
             "url": "https://packages.drupal.org/8"
         }
-    },
-    "extra": {
-        "patches": {
-            "drupal/elasticsearch_connector": {
-                "Allow index name flexibility - https://www.drupal.org/project/elasticsearch_connector/issues/3010955#comment-12998995": "https://www.drupal.org/files/issues/2019-03-05/3010955-10.patch"
-            }
-        }
     }
 }


### PR DESCRIPTION
1. https://www.drupal.org/project/elasticsearch_connector/issues/3166369

> There was an issue with nodespark/des-connector library. It has been fixed so now it should be OK.

our upstream has been fixed the missed dependency, so we don't need the composer alias.

2. https://www.drupal.org/project/elasticsearch_connector/issues/3010955
the PR above is merged, so we don't need the patch. 