### PR TITLE
Updated composer to lock the elasticsearch version to 6.7.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,19 @@
     "require": {
         "drupal/search_api": "^1.11",
         "drupal/elasticsearch_connector": "^6.0-alpha2",
-        "dpc-sdp/tide_core": "^2.0.0",
-        "elasticsearch/elasticsearch": "6.7.2"
+        "dpc-sdp/tide_core": "^2.0.0"
     },
     "repositories": {
         "drupal": {
             "type": "composer",
             "url": "https://packages.drupal.org/8"
+        }
+    },
+    "extra": {
+        "patches": {
+            "drupal/elasticsearch_connector": {
+                "deleteMapping() throws undefined error - https://www.drupal.org/project/elasticsearch_connector/issues/3224368": "https://www.drupal.org/files/issues/2021-07-20/%5BdeleteMapping-throws-undefined-error%5D-%5B3224368%5D-%5B1%5D.patch"
+            }
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "extra": {
         "patches": {
             "drupal/elasticsearch_connector": {
-                "deleteMapping() throws undefined error - https://www.drupal.org/project/elasticsearch_connector/issues/3224368": "https://www.drupal.org/files/issues/2021-07-20/%5BdeleteMapping-throws-undefined-error%5D-%5B3224368%5D-%5B1%5D.patch"
+                "deleteMapping() throws undefined error - https://www.drupal.org/project/elasticsearch_connector/issues/2824539": "https://www.drupal.org/files/issues/2021-07-20/%5BdeleteMapping-throws-undefined-error%5D-%5B3224368%5D-%5B1%5D_0.patch"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "require": {
         "drupal/search_api": "^1.11",
         "drupal/elasticsearch_connector": "^6.0-alpha2",
-        "dpc-sdp/tide_core": "^2.0.0"
+        "dpc-sdp/tide_core": "^2.0.0",
+        "elasticsearch/elasticsearch": "6.7.2"
     },
     "repositories": {
         "drupal": {


### PR DESCRIPTION
### Issue was elasticsearch-php module 6.8.0 version removed a method and elasticseacr_connector module was trying to call that method which resulted in undefined error during the build.
I have created the issue and the patch here. Please have a look - https://www.drupal.org/project/elasticsearch_connector/issues/2824539

As the deleteMapping is not available from any ES version greater than 1.7 and the greater ES 7 version requires 6.8 of elasticsearch-php version, it is safer to just remove it I guess.

This is the content-vic release branch build logs, which has done a clean build with these changes - https://dashboard.amazeeio.cloud/projects/content-vic/content-vic-pr-1164/deployments/lagoon-build-0jhynu
