### PR TITLE
Fixes an index name issue caused by rewrite option

### DIFF
--- a/config/install/elasticsearch_connector.cluster.elasticsearch_bay.yml
+++ b/config/install/elasticsearch_connector.cluster.elasticsearch_bay.yml
@@ -11,3 +11,8 @@ options:
   username: ''
   password: ''
   timeout: '3'
+  rewrite:
+    rewrite_index: 0
+    index:
+      prefix: null
+      suffix: null


### PR DESCRIPTION
### Issue
when checking indices, `/_cat/indices`, we will find some of them are incorrect.
for example, 
```
yellow open b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_referencesdpvicgovaupr39_afy84_node 
yellow open b56de58036ae7d6456d5b246f85ffe88--elasticsearch_index_referencesdpvicgovaupr49_vyfqd_node
```
the issue caused by the `elasticsearch_connector.cluster.elasticsearch_bay` config that doesn't set correctly, which misses `rewrite` option.

### Change
adds `rewrite` options