### PR TITLE
[SDPA-6051] Added changes to exclude tide_alert from data source.

### DIFF
--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Drupal\tide_search;
+
+class TideSearchOperation
+{
+  /**
+   * Remove tide_alert content type from data source if module exists.
+   */
+  public function remove_tide_alert_from_datasource() {
+    if (\Drupal::moduleHandler()->moduleExists('tide_alert')) {
+      $config_factory = \Drupal::configFactory();
+      $config = $config_factory->getEditable('search_api.index.node');
+      $node_datasource_settings = $config->get('datasource_settings.entity:node.bundles.selected');
+      if (!in_array('alert', $node_datasource_settings)) {
+        $node_datasource_settings[] = 'alert';
+        $config->set('datasource_settings.entity:node.bundles.selected', $node_datasource_settings);
+        $config->save();
+      }
+    }
+  }
+}

--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -2,12 +2,12 @@
 
 namespace Drupal\tide_search;
 
-class TideSearchOperation
-{
-  /**
-   * Remove tide_alert content type from data source if module exists.
-   */
-  public function remove_tide_alert_from_datasource() {
+/**
+ * Remove tide_alert content type from data source if module exists.
+ */
+class TideSearchOperation {
+
+  public function removeTideAlertFromDatasource() {
     if (\Drupal::moduleHandler()->moduleExists('tide_alert')) {
       $config_factory = \Drupal::configFactory();
       $config = $config_factory->getEditable('search_api.index.node');
@@ -19,4 +19,5 @@ class TideSearchOperation
       }
     }
   }
+
 }

--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -3,10 +3,11 @@
 namespace Drupal\tide_search;
 
 /**
- * Remove tide_alert content type from data source if module exists.
+ * Tide search modules operations.
  */
 class TideSearchOperation {
 
+  // Remove tide_alert content type from data source if module exists.
   public function removeTideAlertFromDatasource() {
     if (\Drupal::moduleHandler()->moduleExists('tide_alert')) {
       $config_factory = \Drupal::configFactory();

--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -7,7 +7,9 @@ namespace Drupal\tide_search;
  */
 class TideSearchOperation {
 
-  // Remove tide_alert content type from data source if module exists.
+  /**
+   * Remove tide_alert content type from data source if module exists.
+   */
   public function removeTideAlertFromDatasource() {
     if (\Drupal::moduleHandler()->moduleExists('tide_alert')) {
       $config_factory = \Drupal::configFactory();

--- a/tide_search.install
+++ b/tide_search.install
@@ -6,6 +6,15 @@
  */
 
 use Drupal\search_api\Item\Field;
+use Drupal\tide_search\TideSearchOperation;
+
+/**
+ * Implements hook_install().
+ */
+function tide_search_install() {
+  $tideSearchOperation = new TideSearchOperation();
+  $tideSearchOperation->remove_tide_alert_from_datasource();
+}
 
 /**
  * Implements hook_update_dependencies().
@@ -96,4 +105,12 @@ function tide_search_update_8002() {
     $config->set('processor_settings.html_filter.fields', $processor_settings);
   }
   $config->save();
+}
+
+/**
+ * Removes alert content type from indexing.
+ */
+function tide_search_update_8003() {
+  $tideSearchOperation = new TideSearchOperation();
+  $tideSearchOperation->remove_tide_alert_from_datasource();
 }

--- a/tide_search.install
+++ b/tide_search.install
@@ -13,7 +13,7 @@ use Drupal\tide_search\TideSearchOperation;
  */
 function tide_search_install() {
   $tideSearchOperation = new TideSearchOperation();
-  $tideSearchOperation->remove_tide_alert_from_datasource();
+  $tideSearchOperation->removeTideAlertFromDatasource();
 }
 
 /**
@@ -112,5 +112,5 @@ function tide_search_update_8002() {
  */
 function tide_search_update_8003() {
   $tideSearchOperation = new TideSearchOperation();
-  $tideSearchOperation->remove_tide_alert_from_datasource();
+  $tideSearchOperation->removeTideAlertFromDatasource();
 }


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-6051

### Issue
On fresh install and for some projects tide_alert is getting added in the search datasource, which causing the alerts to come up in the site search.

### Changes
If tide_alert exists and module is installed then remove tide_alert from the search index data source