### PR TITLE
Feature/SDPAP-6902 Provide drush support to index specific entity.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,11 @@
         }
     },
     "extra": {
+        "patches": {
+            "drupal/search_api": {
+                "Provide drush support to index a specific entity - https://www.drupal.org/project/search_api/issues/3016809": "https://www.drupal.org/files/issues/2020-02-08/search_api-index-specific-items-3016809-09.patch"
+            }
+        },
         "drush": {
             "services": {
                 "drush.services.yml": "^10"


### PR DESCRIPTION
### JIRA
https://digital-vic.atlassian.net/browse/SDPAP-6902

### Issue
This PR also has the fix for running out of memory error while executing the custom drush commands - 
`drush tide:search-audit-nodes node`

### Changes
1. Added patch to provide drush support to index specific entity. Command to index a node - drush search-api:index-sample node --datasource=entity:node --id-list=31246
2. Fix for `Allowed memory size exhausted`, running index query in much smaller batch of 1000. Also running the entity query in batch of 100, else it also throws out of memory error for bigger data set

### Test Video

https://user-images.githubusercontent.com/20810541/225812211-609859a1-59cc-4054-b7f1-495cac01ede6.mp4

