### PR TITLE
Filter out boost parameters since they are incompatible with ES 8.5

### DIFF
--- a/src/Commands/TideSearchCommands.php
+++ b/src/Commands/TideSearchCommands.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tide_search\Commands;
 
-use Drush\Commands\DrushCommands;
 use Drupal\search_api\Utility\CommandHelper;
+use Drush\Commands\DrushCommands;
 
 /**
  * A Drush commandfile.

--- a/src/ElasticSearch/Parameters/Factory/TideSearchIndexFactory.php
+++ b/src/ElasticSearch/Parameters/Factory/TideSearchIndexFactory.php
@@ -155,7 +155,7 @@ class TideSearchIndexFactory extends IndexFactory {
   /**
    * Build parameters required to create an index mapping.
    *
-   * TODO: We need also:
+   * @todo We need also:
    * $params['index'] - (Required)
    * ['type'] - The name of the document type
    * ['timeout'] - (time) Explicit operation timeout.
@@ -169,7 +169,7 @@ class TideSearchIndexFactory extends IndexFactory {
   public static function mapping(IndexInterface $index) {
     $mapping = parent::mapping($index);
     $filtered = [];
-    foreach($mapping['body']['properties'] as $property_key => $property) {
+    foreach ($mapping['body']['properties'] as $property_key => $property) {
       if (isset($property['boost'])) {
         unset($property['boost']);
       }

--- a/src/ElasticSearch/Parameters/Factory/TideSearchIndexFactory.php
+++ b/src/ElasticSearch/Parameters/Factory/TideSearchIndexFactory.php
@@ -29,6 +29,7 @@ class TideSearchIndexFactory extends IndexFactory {
     $filteredIndexName = str_replace('--', '-', $indexName);
     $aliasPrefix = 'search-' . (\Drupal::request()->server->get('SEARCH_HASH') ?: '') . '-';
     $aliasName = $aliasPrefix . str_replace('_', '-', $filteredIndexName) . '-alias';
+
     $indexConfig = [
       'index' => $indexName,
       'body' => [
@@ -111,7 +112,6 @@ class TideSearchIndexFactory extends IndexFactory {
     $prepareIndexEvent = new PrepareIndexEvent($indexConfig, $indexName);
     $event = $dispatcher->dispatch($prepareIndexEvent, PrepareIndexEvent::PREPARE_INDEX);
     $indexConfig = $event->getIndexConfig();
-
     return $indexConfig;
   }
 
@@ -150,6 +150,34 @@ class TideSearchIndexFactory extends IndexFactory {
     }
 
     return $params;
+  }
+
+  /**
+   * Build parameters required to create an index mapping.
+   *
+   * TODO: We need also:
+   * $params['index'] - (Required)
+   * ['type'] - The name of the document type
+   * ['timeout'] - (time) Explicit operation timeout.
+   *
+   * @param \Drupal\search_api\IndexInterface $index
+   *   Index object.
+   *
+   * @return array
+   *   Parameters required to create an index mapping.
+   */
+  public static function mapping(IndexInterface $index) {
+    $mapping = parent::mapping($index);
+    $filtered = [];
+    foreach($mapping['body']['properties'] as $property_key => $property) {
+      if (isset($property['boost'])) {
+        unset($property['boost']);
+      }
+      $filtered[$property_key] = $property;
+    };
+    $mapping['body']['properties'] = $filtered;
+
+    return $mapping;
   }
 
 }

--- a/src/TideSearchServiceProvider.php
+++ b/src/TideSearchServiceProvider.php
@@ -2,8 +2,8 @@
 
 namespace Drupal\tide_search;
 
-use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
 
 /**
  * Replaces the queuers and processors plugin managers with failing stubs.


### PR DESCRIPTION
The boost parameter is incompatible with ES 8.5 as per the following URL:
https://www.drupal.org/project/elasticsearch_connector/issues/3183164

Until such time as a patch is organised, we can use our extended class in tide_search to filter out this parameter.

This also seems to resolve index time creation format issues with keyword fields. I assume the error was causing proper index time mapping creation to complete successfully.