### PR TITLE
Update search api base config for Ripple 2.0 fields

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
   },
   "require": {
     "dpc-sdp/tide_core": "^3.0.0",
+    "dpc-sdp/tide_landing_page": "^3.0.0",
     "drupal/elasticsearch_connector": "^7.0",
     "drupal/search_api": "^1.11"
   },

--- a/config/install/search_api.index.node.yml
+++ b/config/install/search_api.index.node.yml
@@ -5,6 +5,11 @@ dependencies:
     - field.storage.node.body
     - field.storage.node.field_topic
     - field.storage.node.field_tags
+    - field.storage.node.field_landing_page_component
+    - field.storage.paragraph.field_paragraph_body
+    - field.storage.paragraph.field_paragraph_summary
+    - field.storage.node.field_event_details
+    - field.storage.paragraph.field_paragraph_location
     - search_api.server.elasticsearch_bay
   module:
     - taxonomy
@@ -91,6 +96,39 @@ field_settings:
       module:
         - taxonomy
         - path
+  field_event_details_event_locality:
+    label: 'Event Details » Location » The locality'
+    datasource_id: 'entity:node'
+    property_path: 'field_event_details:entity:field_paragraph_location:locality'
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_event_details
+        - field.storage.paragraph.field_paragraph_location
+      module:
+        - paragraphs
+    field_paragraph_body:
+      label: 'Content components » Paragraph » Body'
+      datasource_id: 'entity:node'
+      property_path: 'field_landing_page_component:entity:field_paragraph_body'
+      type: text
+      dependencies:
+        config:
+          - field.storage.node.field_landing_page_component
+          - field.storage.paragraph.field_paragraph_body
+        module:
+          - paragraphs
+    field_paragraph_summary:
+      label: 'Content components » Paragraph » Summary'
+      datasource_id: 'entity:node'
+      property_path: 'field_landing_page_component:entity:field_paragraph_summary'
+      type: text
+      dependencies:
+        config:
+          - field.storage.node.field_landing_page_component
+          - field.storage.paragraph.field_paragraph_summary
+        module:
+          - paragraphs
   status:
     label: Published
     datasource_id: 'entity:node'
@@ -191,6 +229,9 @@ processor_settings:
       - field_topic_path
       - field_tags_name
       - field_tags_path
+      - field_paragraph_body
+      - field_paragraph_summary
+      - field_event_details_event_locality
       - uuid
       - field_tags_uuid
       - field_topic_uuid

--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -312,7 +312,7 @@ class TideSearchOperation {
         ],
       ],
     ];
-    $config->set('dependencies.field_settings', $fields);
+    $config->set('field_settings', $fields);
 
     $filters = $config->get('processor_settings.html_filter.fields');
     $new_filters = [

--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -244,4 +244,90 @@ class TideSearchOperation {
     $config->save();
   }
 
+  /**
+   * Ensure that the required field config for search for Ripple 2.0 is present.
+   */
+  public function setCoreSearchApiFields() {
+    error_log(" tide_search - setting core search api fields for ripple 2.0");
+    $config = \Drupal::configFactory()->getEditable('search_api.index.node');
+
+    $dependencies = $config->get('dependencies.config');
+    $new_dependencies = [
+      'field.storage.node.field_landing_page_component',
+      'field.storage.paragraph.field_paragraph_body',
+      'field.storage.paragraph.field_paragraph_summary',
+      'field.storage.node.field_event_details',
+      'field.storage.paragraph.field_paragraph_location',
+    ];
+    foreach ($new_dependencies as $new_dependency) {
+      if (!in_array($new_dependency, $dependencies)) {
+        $dependencies[] = $new_dependency;
+      }
+    }
+    $config->set('dependencies.config', $dependencies);
+
+    $fields = $config->get('field_settings');
+    $fields['field_event_details_event_locality'] = [
+      'label' => 'Event Details » Location » The locality',
+      'datasource_id' => 'entity:node',
+      'property_path' => 'field_event_details:entity:field_paragraph_location:locality',
+      'type' => 'text',
+      'dependencies' => [
+        'config' => [
+          'field.storage.node.field_event_details',
+          'field.storage.paragraph.field_paragraph_location',
+        ],
+        'module' => [
+          'paragraphs',
+        ],
+      ],
+    ];
+    $fields['field_paragraph_body'] = [
+      'label' => 'Content components » Paragraph » Body',
+      'datasource_id' => 'entity:node',
+      'property_path' => 'field_landing_page_component:entity:field_paragraph_body',
+      'type' => 'text',
+      'dependencies' => [
+        'config' => [
+          'field.storage.node.field_landing_page_component',
+          'field.storage.paragraph.field_paragraph_body',
+        ],
+        'module' => [
+          'paragraphs',
+        ],
+      ],
+    ];
+    $fields['field_paragraph_summary'] = [
+      'label' => 'Content components » Paragraph » Summary',
+      'datasource_id' => 'entity:node',
+      'property_path' => 'field_landing_page_component:entity:field_paragraph_summary',
+      'type' => 'text',
+      'dependencies' => [
+        'config' => [
+          'field.storage.node.field_landing_page_component',
+          'field.storage.paragraph.field_paragraph_summary',
+        ],
+        'module' => [
+          'paragraphs',
+        ],
+      ],
+    ];
+    $config->set('dependencies.field_settings', $fields);
+
+    $filters = $config->get('processor_settings.html_filter.fields');
+    $new_filters = [
+      'field_paragraph_body',
+      'field_paragraph_summary',
+      'field_event_details_event_locality',
+    ];
+    foreach ($new_filters as $new_filter) {
+      if (!in_array($new_filter, $filters)) {
+        $filters[] = $new_filter;
+      }
+    }
+    $config->set('processor_settings.html_filter.fields', $filters);
+
+    $config->save();
+  }
+
 }

--- a/tide_search.info.yml
+++ b/tide_search.info.yml
@@ -7,3 +7,5 @@ dependencies:
   - search_api:search_api
   - elasticsearch_connector:elasticsearch_connector
   - dpc-sdp:tide_core
+  - dpc-sdp:tide_landing_page
+  - paragraphs

--- a/tide_search.install
+++ b/tide_search.install
@@ -143,7 +143,7 @@ function tide_search_update_8004() {
 }
 
 /**
- * Update search api fields for Ripple 2.0 search
+ * Update search api fields for Ripple 2.0 search.
  */
 function tide_search_update_8005() {
   $moduleHandler = \Drupal::service('module_handler');

--- a/tide_search.install
+++ b/tide_search.install
@@ -141,3 +141,14 @@ function tide_search_update_8004() {
   );
   $tideSearchOperation->addSearchableFieldsTerms();
 }
+
+/**
+ * Update search api fields for Ripple 2.0 search
+ */
+function tide_search_update_8005() {
+  $moduleHandler = \Drupal::service('module_handler');
+  if ($moduleHandler->moduleExists('paragraphs') && $moduleHandler->moduleExists('tide_landing_page')) {
+    $tideSearchOperation = new TideSearchOperation();
+    $tideSearchOperation->setCoreSearchApiFields();
+  }
+}

--- a/tide_search.install
+++ b/tide_search.install
@@ -22,7 +22,7 @@ function tide_search_install() {
 function tide_search_update_dependencies() {
   $dependencies = [];
   $dependencies['tide_search'][8001] = ['tide_core' => 8009];
-
+  $dependencies['tide_search'][8005] = ['tide_landing_page' => 8050];
   return $dependencies;
 }
 


### PR DESCRIPTION
These fields are required for all base ripple 2.0 search queries, so we will need the update hook on all CMS that get 1.46 to bring them in line.

Note that I have done a dependency check on tide landing page and paragraphs as both are required for these fields to be added and valid.