### PR TITLE
[R20-1547] Add secondary campaign to search listing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     }
   },
   "require": {
-    "dpc-sdp/tide_core": "^3.0.0",
-    "dpc-sdp/tide_landing_page": "^3.0.0",
+    "dpc-sdp/tide_core": "dev-reference",
+    "dpc-sdp/tide_landing_page": "dev-reference",
     "drupal/elasticsearch_connector": "^7.0",
     "drupal/search_api": "^1.11",
     "drupal/data_pipelines": "^1.0@alpha",

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     }
   },
   "require": {
-    "dpc-sdp/tide_core": "dev-reference",
-    "dpc-sdp/tide_landing_page": "dev-reference",
+    "dpc-sdp/tide_core": "^3.0.0",
+    "dpc-sdp/tide_landing_page": "^3.0.0",
     "drupal/elasticsearch_connector": "^7.0",
     "drupal/search_api": "^1.11",
     "drupal/data_pipelines": "^1.0@alpha",

--- a/config/optional/core.entity_form_display.node.tide_search_listing.default.yml
+++ b/config/optional/core.entity_form_display.node.tide_search_listing.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.tide_search_listing.field_custom_sort_configuration
     - field.field.node.tide_search_listing.field_featured_image
     - field.field.node.tide_search_listing.field_header_components
+    - field.field.node.tide_search_listing.field_landing_page_c_secondary
     - field.field.node.tide_search_listing.field_landing_page_intro_text
     - field.field.node.tide_search_listing.field_landing_page_summary
     - field.field.node.tide_search_listing.field_layout_component
@@ -142,7 +143,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 13
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -192,6 +193,16 @@ content:
         add_above: '0'
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
+    third_party_settings: {  }
+  field_landing_page_c_secondary:
+    type: entity_reference_autocomplete
+    weight: 9
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
     third_party_settings: {  }
   field_landing_page_intro_text:
     type: string_textarea
@@ -286,7 +297,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 21
+    weight: 22
     region: content
     settings:
       sidebar: true
@@ -294,14 +305,14 @@ content:
     third_party_settings: {  }
   field_node_primary_site:
     type: options_buttons
-    weight: 23
+    weight: 24
     region: content
     settings: {  }
     third_party_settings: {  }
     field_name: field_node_primary_site
   field_node_site:
     type: options_buttons
-    weight: 22
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -343,14 +354,14 @@ content:
     third_party_settings: {  }
   field_show_content_rating:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_tags:
     type: entity_reference_autocomplete
-    weight: 20
+    weight: 21
     region: content
     settings:
       match_operator: CONTAINS
@@ -360,7 +371,7 @@ content:
     third_party_settings: {  }
   field_topic:
     type: entity_reference_autocomplete
-    weight: 9
+    weight: 10
     region: content
     settings:
       match_operator: CONTAINS
@@ -370,38 +381,38 @@ content:
     third_party_settings: {  }
   moderation_state:
     type: moderation_state_default
-    weight: 19
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   path:
     type: path
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 10
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   simple_sitemap:
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 17
+    weight: 18
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 14
+    weight: 15
     region: content
     settings:
       display_label: true
@@ -416,7 +427,7 @@ content:
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 12
+    weight: 13
     region: content
     settings:
       match_operator: CONTAINS
@@ -425,7 +436,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   url_redirects:
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/config/optional/core.entity_view_display.node.tide_search_listing.default.yml
+++ b/config/optional/core.entity_view_display.node.tide_search_listing.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.tide_search_listing.field_custom_sort_configuration
     - field.field.node.tide_search_listing.field_featured_image
     - field.field.node.tide_search_listing.field_header_components
+    - field.field.node.tide_search_listing.field_landing_page_c_secondary
     - field.field.node.tide_search_listing.field_landing_page_intro_text
     - field.field.node.tide_search_listing.field_landing_page_summary
     - field.field.node.tide_search_listing.field_layout_component
@@ -72,6 +73,14 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 112
+    region: content
+  field_landing_page_c_secondary:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 121
     region: content
   field_landing_page_intro_text:
     type: basic_string

--- a/config/optional/core.entity_view_display.node.tide_search_listing.teaser.yml
+++ b/config/optional/core.entity_view_display.node.tide_search_listing.teaser.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.tide_search_listing.field_custom_sort_configuration
     - field.field.node.tide_search_listing.field_featured_image
     - field.field.node.tide_search_listing.field_header_components
+    - field.field.node.tide_search_listing.field_landing_page_c_secondary
     - field.field.node.tide_search_listing.field_landing_page_intro_text
     - field.field.node.tide_search_listing.field_landing_page_summary
     - field.field.node.tide_search_listing.field_layout_component
@@ -48,6 +49,7 @@ hidden:
   field_custom_sort_configuration: true
   field_featured_image: true
   field_header_components: true
+  field_landing_page_c_secondary: true
   field_landing_page_intro_text: true
   field_landing_page_summary: true
   field_layout_component: true

--- a/config/optional/field.field.node.tide_search_listing.field_landing_page_c_secondary.yml
+++ b/config/optional/field.field.node.tide_search_listing.field_landing_page_c_secondary.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_landing_page_c_secondary
+    - node.type.tide_search_listing
+id: node.tide_search_listing.field_landing_page_c_secondary
+field_name: field_landing_page_c_secondary
+entity_type: node
+bundle: tide_search_listing
+label: 'Secondary campaign'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:block_content'
+  handler_settings: {  }
+field_type: entity_reference

--- a/tide_search.install
+++ b/tide_search.install
@@ -169,9 +169,9 @@ function tide_search_update_8006() {
 function tide_search_update_8007() {
   $configs = [
     'field.field.node.tide_search_listing.field_landing_page_c_secondary' => 'field_config',
-    'core.entity_view_display.node.tide_search_listing.teaser' => 'entity_view_display',
     'core.entity_view_display.node.tide_search_listing.default' => 'entity_view_display',
     'core.entity_form_display.node.tide_search_listing.default' => 'entity_form_display',
+    'core.entity_view_display.node.tide_search_listing.teaser' => 'entity_view_display',
   ];
 
   \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');

--- a/tide_search.install
+++ b/tide_search.install
@@ -162,3 +162,30 @@ function tide_search_update_8006() {
     $module_installer->install(['tide_data_pipeline']);
   }
 }
+
+/**
+ * Add secondary campaign to search listing.
+ */
+function tide_search_update_8007() {
+  $configs = [
+    'field.field.node.tide_search_listing.field_landing_page_c_secondary' => 'field_config',
+    'core.entity_view_display.node.tide_search_listing.teaser' => 'entity_view_display',
+    'core.entity_view_display.node.tide_search_listing.default' => 'entity_view_display',
+    'core.entity_form_display.node.tide_search_listing.default' => 'entity_form_display',
+  ];
+
+  \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
+  foreach ($configs as $config => $type) {
+    $config_read = _tide_read_config(
+      $config,
+      [\Drupal::service('extension.list.module')->getPath('tide_search') . '/config/optional'],
+      TRUE
+    );
+    $storage = \Drupal::entityTypeManager()->getStorage($type);
+    $id = substr($config, strrpos($config, '.') + 1);
+    if ($storage->load($id) == NULL) {
+      $config_entity = $storage->createFromStorageRecord($config_read);
+      $config_entity->save();
+    }
+  }
+}

--- a/tide_search.install
+++ b/tide_search.install
@@ -167,25 +167,30 @@ function tide_search_update_8006() {
  * Add secondary campaign to search listing.
  */
 function tide_search_update_8007() {
-  $configs = [
-    'field.field.node.tide_search_listing.field_landing_page_c_secondary' => 'field_config',
-    'core.entity_view_display.node.tide_search_listing.default' => 'entity_view_display',
-    'core.entity_form_display.node.tide_search_listing.default' => 'entity_form_display',
-    'core.entity_view_display.node.tide_search_listing.teaser' => 'entity_view_display',
-  ];
-
   \Drupal::moduleHandler()->loadInclude('tide_core', 'inc', 'includes/helpers');
-  foreach ($configs as $config => $type) {
-    $config_read = _tide_read_config(
-      $config,
-      [\Drupal::service('extension.list.module')->getPath('tide_search') . '/config/optional'],
-      TRUE
-    );
-    $storage = \Drupal::entityTypeManager()->getStorage($type);
-    $id = substr($config, strrpos($config, '.') + 1);
-    if ($storage->load($id) == NULL) {
-      $config_entity = $storage->createFromStorageRecord($config_read);
-      $config_entity->save();
-    }
+  $config_location = [\Drupal::service('extension.list.module')->getPath('tide_search') . '/config/optional'];
+
+  $config = 'field.field.node.tide_search_listing.field_landing_page_c_secondary';
+  $type = 'field_config';
+  $config_read = _tide_read_config($config, $config_location);
+  $storage = \Drupal::entityTypeManager()->getStorage($type);
+  $id = substr($config, strrpos($config, '.') + 1);
+  if ($storage->load($id) == NULL) {
+    $config_entity = $storage->createFromStorageRecord($config_read);
+    $config_entity->save();
+  }
+
+  $form_configs = [
+    'core.entity_view_display.node.tide_search_listing.default',
+    'core.entity_form_display.node.tide_search_listing.default',
+    'core.entity_view_display.node.tide_search_listing.teaser',
+  ];
+  foreach ($form_configs as $form_config) {
+    $config = \Drupal::configFactory()->getEditable($form_config);
+    $config_read = _tide_read_config($form_config, $config_location, FALSE);
+    $config->set('dependencies', $config_read['dependencies']);
+    $config->set('content', $config_read['content']);
+    $config->set('hidden', $config_read['hidden']);
+    $config->save();
   }
 }


### PR DESCRIPTION
This PR adds the existing secondary campaign field to search listing, at the bottom of the UI, to allow search listing pages to use the existing secondary campaign features in the front end.