### PR TITLE
Add the base set of taxonomy to all CMS

### DIFF
--- a/tide_search.install
+++ b/tide_search.install
@@ -194,3 +194,72 @@ function tide_search_update_8007() {
     $config->save();
   }
 }
+
+/**
+ * Add default set of terms to searchable fields vocab.
+ */
+function tide_search_update_8008() {
+  $vid = 'searchable_fields';
+  $terms = [
+    [
+      'name' => 'Audience (Grants)',
+      'field_elasticsearch_field' => 'field_audience_name',
+      'field_taxonomy_machine_name' => 'audience',
+    ],
+    [
+      'name' => 'Content cateory',
+      'field_elasticsearch_field' => 'field_content_category',
+      'field_taxonomy_machine_name' => 'content_category',
+    ],
+    [
+      'name' => 'Department',
+      'field_elasticsearch_field' => 'field_department_agency',
+      'field_taxonomy_machine_name' => 'department',
+    ],
+    [
+      'name' => 'Event category',
+      'field_elasticsearch_field' => 'field_event_category',
+      'field_taxonomy_machine_name' => 'event',
+    ],
+    [
+      'name' => 'Event requirements',
+      'field_elasticsearch_field' => 'field_event_details_event_requirements_name',
+      'field_taxonomy_machine_name' => 'event_requirements',
+    ],
+    [
+      'name' => 'Sites and site sections',
+      'field_elasticsearch_field' => 'field_node_site',
+      'field_taxonomy_machine_name' => 'sites',
+    ],
+    [
+      'name' => 'Tags',
+      'field_elasticsearch_field' => 'field_tags',
+      'field_taxonomy_machine_name' => 'tags',
+    ],
+    [
+      'name' => 'Topic',
+      'field_elasticsearch_field' => 'field_topic_name',
+      'field_taxonomy_machine_name' => 'topic',
+    ],
+  ];
+  $existing_terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadTree($vid);
+  foreach ($terms as $term) {
+    $insert = TRUE;
+    foreach ($existing_terms as $existing_term) {
+      if ($existing_term->name == $term['name']) {
+        error_log("Cannot insert term ".$term['name']." as it's already present against searchable_fields vocab.");
+        $insert = FALSE;
+      }
+    }
+    if ($insert) {
+      error_log("Inserting ".$term['name']." against searchable_fields vocab.");
+      Term::create([
+        'name' => $term['name'],
+        'vid' => $vid,
+        'field_elasticsearch_field' => $term['field_elasticsearch_field'],
+        'field_taxonomy_machine_name' => $term['field_taxonomy_machine_name'],
+        'parent' => [],
+      ])->save();
+    }
+  }
+}


### PR DESCRIPTION
These are the base 8 terms for searchable fields that exist in reference, they will need to be added to all CMS as per the discussion in https://digital-vic.atlassian.net/browse/SDPAP-8338

When you run this update in reference you will get:
```
> Cannot insert term Audience (Grants) as it's already present against searchable_fields vocab.
> Cannot insert term Content cateory as it's already present against searchable_fields vocab.
> Cannot insert term Department as it's already present against searchable_fields vocab.
> Cannot insert term Event category as it's already present against searchable_fields vocab.
> Cannot insert term Event requirements as it's already present against searchable_fields vocab.
> Cannot insert term Sites and site sections as it's already present against searchable_fields vocab.
> Cannot insert term Tags as it's already present against searchable_fields vocab.
> Cannot insert term Topic as it's already present against searchable_fields vocab.
```

This is expected as the terms already exist in reference, we are ensuring they get installed in all CMS that end up with search listing for wide compatibility across the install base.