### PR TITLE
Add a check for a second id before creating storage

### DIFF
--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -122,8 +122,7 @@ class TideSearchOperation {
       $storage = \Drupal::entityTypeManager()->getStorage($type);
       $id = substr($config, strrpos($config, '.') + 1);
       if ($storage->load($id) == NULL) {
-        // Try using an extended id as well, e.g.
-        // field.storage.paragraph.field_header_configuration will try paragraph.field_header_configuration.
+        // Try using an extended id as well.
         $id = substr($config, strrpos($config, '.', strrpos($config, '.') - strlen($config) - 1) + 1);
         if ($storage->load($id) == NULL) {
           error_log(" tide_search - importing config: " . $id);
@@ -149,7 +148,7 @@ class TideSearchOperation {
   }
 
   /**
-   * Add permissions for the search listing content type.`
+   * Add permissions for the search listing content type.
    */
   public function addSearchListingPermissions() {
     $role = Role::load('site_admin');

--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -122,9 +122,14 @@ class TideSearchOperation {
       $storage = \Drupal::entityTypeManager()->getStorage($type);
       $id = substr($config, strrpos($config, '.') + 1);
       if ($storage->load($id) == NULL) {
-        error_log(" tide_search - importing config: " . $id);
-        $config_entity = $storage->createFromStorageRecord($config_read);
-        $config_entity->save();
+        // Try using an extended id as well, e.g.
+        // field.storage.paragraph.field_header_configuration will try paragraph.field_header_configuration
+        $id = substr($config, strrpos($config, '.', strrpos($config, '.') - strlen($config) - 1) + 1);
+        if ($storage->load($id) == NULL) {
+          error_log(" tide_search - importing config: " . $id);
+          $config_entity = $storage->createFromStorageRecord($config_read);
+          $config_entity->save();
+        }
       }
     }
   }

--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -123,7 +123,7 @@ class TideSearchOperation {
       $id = substr($config, strrpos($config, '.') + 1);
       if ($storage->load($id) == NULL) {
         // Try using an extended id as well, e.g.
-        // field.storage.paragraph.field_header_configuration will try paragraph.field_header_configuration
+        // field.storage.paragraph.field_header_configuration will try paragraph.field_header_configuration.
         $id = substr($config, strrpos($config, '.', strrpos($config, '.') - strlen($config) - 1) + 1);
         if ($storage->load($id) == NULL) {
           error_log(" tide_search - importing config: " . $id);
@@ -149,7 +149,7 @@ class TideSearchOperation {
   }
 
   /**
-   * Add permissions for the search listing content type.
+   * Add permissions for the search listing content type.`
    */
   public function addSearchListingPermissions() {
     $role = Role::load('site_admin');


### PR DESCRIPTION
Original hook was stripping everything to the right of the last period in the config name in order to find the id of the storage element. This works for most configs, but some need to strip everything to the right of the _second last_ period. This change adds a small check to try that as well.