### PR TITLE
[SDPSUP-6512] Restrict modification of field_search_configuration to administrators

### DIFF
--- a/src/TideSearchOperation.php
+++ b/src/TideSearchOperation.php
@@ -334,5 +334,27 @@ class TideSearchOperation {
 
     $config->save();
   }
-
+  
+  /**
+   * Defines the name of the field that contains elasticsearch query config.
+   */
+  const SEARCH_CONFIG_FIELD = "field_search_configuration";
+  
+  /**
+   * Restricts field_search_configuration to administrators.
+   */
+  public function restrictFieldSearchConfiguration() {
+    $config_factory = \Drupal::configFactory();
+    $config = $config_factory->getEditable('field.storage.node.field_search_configuration');
+    $config->set('third_party_settings', ['field_permissions' => ['permission_type' => 'custom']]);
+    $config->save();
+    
+    foreach (["anonymous", "authenticated"] as $role_id) {
+      $role = \Drupal::entityTypeManager()->getStorage('user_role')->load($role_id);
+      $role->grantPermission(sprintf("view %s", self::SEARCH_CONFIG_FIELD));
+      $role->grantPermission(sprintf("view own %s", self::SEARCH_CONFIG_FIELD));
+      $role->save();
+    }
+  }
+  
 }

--- a/tide_search.install
+++ b/tide_search.install
@@ -117,3 +117,11 @@ function tide_search_update_10004() {
   _tide_core_field_content_category_default_value('tide_search_listing', 'Search listing');
   _tide_core_content_category_form_display('tide_search_listing');
 }
+
+/**
+ * Restricts field_search_configuration to administrators.
+ */
+function tide_search_update_10005() {
+  $tideSearchOperation = new TideSearchOperation();
+  $tideSearchOperation->restrictFieldSearchConfiguration();
+}


### PR DESCRIPTION
## Changes

Alters `field_search_configuration` config to enable [field_permissions](https://www.drupal.org/project/field_permissions) with the following permissions.

- `administrator` role can *modify* the field value.
- `anonymous` and `authenticated` roles can *view* the field value (this is to prevent Drupal from excluding this data through JSON:API).

## Motivation

This field is really for developers to configure bespoke search collection pages, not for CMS users to use. Hiding this field from view will hopefully reduce some misunderstandings.