### PR TITLE
Incompatible with search_api 8.x-1.35 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,9 @@
       "drupal/data_pipelines": {
         "CSV data header row whitespace needs to be cleaned up - https://drupal.org/project/data_pipelines/issues/3391214": "https://www.drupal.org/files/issues/2023-10-03/trim-whitespace-from-csv-header-names-3391214-2.patch",
         "set a default value based on certain criteria - https://www.drupal.org/project/data_pipelines/issues/3426248#comment-15507258": "https://www.drupal.org/files/issues/2024-03-21/data_pipelines-3426248-6.patch.patch"
+      },
+      "drupal/elasticsearch_connector": {
+        "Incompatible with recent search_api 8.x-1.35 release - https://www.drupal.org/project/elasticsearch_connector/issues/3455006#comment-15644881": "https://www.drupal.org/files/issues/2024-06-18/elasticsearch_connector-fix_sleep_method_compatibility-3455006-7.patch"
       }
     },
     "drush": {


### PR DESCRIPTION
### Issue

When updating to drupal/search_api 8.x-1.35 release the website will throw following fatal error:

```php
PHP message: PHP Fatal error:  Declaration of Drupal\elasticsearch_connector\Plugin\search_api\backend\SearchApiElasticsearchBackend::__sleep() must be compatible with Drupal\search_api\Backend\BackendPluginBase::__sleep(): array in /var/www/html/docroot/modules/contrib/elasticsearch_connector/src/Plugin/search_api/backend/SearchApiElasticsearchBackend.php on line 1236
```

### FIX
- https://www.drupal.org/project/elasticsearch_connector/issues/3455006